### PR TITLE
Live data

### DIFF
--- a/frontend/app/App.js
+++ b/frontend/app/App.js
@@ -22,8 +22,8 @@ export default function App() {
 
   async function checkLiveStatus() {
     try {
-      const status = await fetchLiveStatus();
-      setLiveStatus(status);
+      const newLiveStatus = await fetchLiveStatus();
+      setLiveStatus(newLiveStatus);
     } catch (error) {
       setLiveStatus({ live: false, packages: [], sampling_rate: 0 });
     }
@@ -31,8 +31,10 @@ export default function App() {
 
   useEffect(() => {
     checkLiveStatus();
-    const intervalID = setInterval(checkLiveStatus, 60000);
-    return () => clearInterval(intervalID);
+    const intervalID = setInterval(checkLiveStatus, 5000);
+    return () => {
+      clearInterval(intervalID);
+    };
   }, []);
 
   return (

--- a/frontend/app/App.js
+++ b/frontend/app/App.js
@@ -21,8 +21,12 @@ export default function App() {
   });
 
   async function checkLiveStatus() {
-    const status = await fetchLiveStatus();
-    setLiveStatus(status);
+    try {
+      const status = await fetchLiveStatus();
+      setLiveStatus(status);
+    } catch (error) {
+      setLiveStatus({ live: false, packages: [], sampling_rate: 0 });
+    }
   }
 
   useEffect(() => {

--- a/frontend/app/App.js
+++ b/frontend/app/App.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import { NavigationContainer } from "@react-navigation/native";
 import { createBottomTabNavigator } from "@react-navigation/bottom-tabs";
 import { ThemeProvider } from "react-native-elements";
@@ -9,25 +9,44 @@ import {
   SteelFrameScreen,
 } from "./src/screens";
 import { Header } from "./src/components";
-import { theme } from "./src/utils";
+import { theme, LiveStatusContext, fetchLiveStatus } from "./src/utils";
 
 const Tab = createBottomTabNavigator();
 
 export default function App() {
+  const [liveStatus, setLiveStatus] = useState({
+    live: false,
+    packages: [],
+    sampling_rate: 0,
+  });
+
+  async function checkLiveStatus() {
+    const status = await fetchLiveStatus();
+    setLiveStatus(status);
+  }
+
+  useEffect(() => {
+    checkLiveStatus();
+    const intervalID = setInterval(checkLiveStatus, 60000);
+    return () => clearInterval(intervalID);
+  }, []);
+
   return (
     <ThemeProvider theme={theme}>
-      <Header />
-      <NavigationContainer>
-        <Tab.Navigator
-          tabBarOptions={{
-            activeTintColor: theme.colors.actionable,
-          }}
-        >
-          <Tab.Screen name="Basement" component={BasementScreen} />
-          <Tab.Screen name="Strong Floor" component={StrongFloorScreen} />
-          <Tab.Screen name="Steel Frame" component={SteelFrameScreen} />
-        </Tab.Navigator>
-      </NavigationContainer>
+      <LiveStatusContext.Provider value={liveStatus}>
+        <Header />
+        <NavigationContainer>
+          <Tab.Navigator
+            tabBarOptions={{
+              activeTintColor: theme.colors.actionable,
+            }}
+          >
+            <Tab.Screen name="Basement" component={BasementScreen} />
+            <Tab.Screen name="Strong Floor" component={StrongFloorScreen} />
+            <Tab.Screen name="Steel Frame" component={SteelFrameScreen} />
+          </Tab.Navigator>
+        </NavigationContainer>
+      </LiveStatusContext.Provider>
     </ThemeProvider>
   );
 }

--- a/frontend/app/App.js
+++ b/frontend/app/App.js
@@ -47,9 +47,9 @@ export default function App() {
               activeTintColor: theme.colors.actionable,
             }}
           >
-            <Tab.Screen name="Basement" component={BasementScreen} />
-            <Tab.Screen name="Strong Floor" component={StrongFloorScreen} />
             <Tab.Screen name="Steel Frame" component={SteelFrameScreen} />
+            <Tab.Screen name="Strong Floor" component={StrongFloorScreen} />
+            <Tab.Screen name="Basement" component={BasementScreen} />
           </Tab.Navigator>
         </NavigationContainer>
       </LiveStatusContext.Provider>

--- a/frontend/app/src/components/Chart.js
+++ b/frontend/app/src/components/Chart.js
@@ -69,7 +69,7 @@ const Decorators = ({ x, y, data: datasets, timestamps }) =>
   );
 
 export default function Chart(props) {
-  const { data, chartOptions } = props;
+  const { data, liveData, liveMode, chartOptions } = props;
 
   const [width, setWidth] = useState(0);
   const [datasets, setDatasets] = useState([]);
@@ -84,16 +84,18 @@ export default function Chart(props) {
       chartOptions.sensors
         .filter(({ isSelected }) => isSelected)
         .map(({ name, colour }) => ({
-          data: data.map((sample) => sample[name]),
+          data: (liveMode ? liveData : data).map((sample) => sample[name]),
           svg: { stroke: colour },
           label: name,
         }))
     );
-  }, [data, chartOptions.sensors]);
+  }, [data, liveData, liveMode, chartOptions.sensors]);
 
   useEffect(() => {
-    setTimestamps(data.map((sample) => sample.timestamp));
-  }, [data]);
+    setTimestamps(
+      liveMode ? [...Array(35).keys()] : data.map((sample) => sample.timestamp)
+    );
+  }, [data, liveMode]);
 
   useEffect(() => {
     setMinX(timestamps[0]);
@@ -251,7 +253,7 @@ export default function Chart(props) {
           style={{ height: 25, marginHorizontal: 35, marginTop: 10 }}
           data={[minX, maxX]}
           xAccessor={({ item }) => item}
-          formatLabel={formatTimestampLabel}
+          formatLabel={liveMode ? (value) => value : formatTimestampLabel}
           contentInset={contentInset}
           svg={{ fontSize: 10, fill: theme.colors.primary }}
           numberOfTicks={5}

--- a/frontend/app/src/components/Header.js
+++ b/frontend/app/src/components/Header.js
@@ -1,20 +1,22 @@
-import React from "react";
+import React, { useContext } from "react";
 import { Image } from "react-native";
 import { Header as HeaderBar } from "react-native-elements";
 
-import { theme } from "../utils";
+import { theme, LiveStatusContext } from "../utils";
 
 export default function Header() {
+  const liveStatus = useContext(LiveStatusContext);
+
   return (
     <HeaderBar
       containerStyle={{
         height: 70,
         paddingVertical: 20,
         paddingHorizontal: 20,
-        borderBottomColor: theme.colors.secondary
+        borderBottomColor: theme.colors.secondary,
       }}
       statusBarProps={{
-        hidden: true
+        hidden: true,
       }}
       placement="left"
       backgroundColor={theme.colors.secondary}

--- a/frontend/app/src/components/Header.js
+++ b/frontend/app/src/components/Header.js
@@ -7,17 +7,17 @@ import { theme, LiveStatusContext } from "../utils";
 export default function Header() {
   const { live } = useContext(LiveStatusContext);
 
-  animVal = useRef(new Animated.Value(1)).current;
+  opacity = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
     Animated.loop(
       Animated.sequence([
-        Animated.timing(animVal, {
+        Animated.timing(opacity, {
           toValue: 0,
           duration: 600,
           useNativeDriver: true,
         }),
-        Animated.timing(animVal, {
+        Animated.timing(opacity, {
           toValue: 1,
           delay: 200,
           duration: 600,
@@ -71,7 +71,7 @@ export default function Header() {
               >
                 Live
               </Text>
-              <Animated.View style={{ opacity: animVal }}>
+              <Animated.View style={{ opacity: opacity }}>
                 <Icon name="controller-record" type="entypo" color="#f54842" />
               </Animated.View>
             </View>

--- a/frontend/app/src/components/Header.js
+++ b/frontend/app/src/components/Header.js
@@ -1,11 +1,31 @@
-import React, { useContext } from "react";
-import { Image } from "react-native";
-import { Header as HeaderBar } from "react-native-elements";
+import React, { useContext, useEffect, useRef } from "react";
+import { View, Image, Text, Animated } from "react-native";
+import { Header as HeaderBar, Icon } from "react-native-elements";
 
 import { theme, LiveStatusContext } from "../utils";
 
 export default function Header() {
-  const liveStatus = useContext(LiveStatusContext);
+  const { live } = useContext(LiveStatusContext);
+
+  animVal = useRef(new Animated.Value(1)).current;
+
+  useEffect(() => {
+    Animated.loop(
+      Animated.sequence([
+        Animated.timing(animVal, {
+          toValue: 0,
+          duration: 600,
+          useNativeDriver: true,
+        }),
+        Animated.timing(animVal, {
+          toValue: 1,
+          delay: 200,
+          duration: 600,
+          useNativeDriver: true,
+        }),
+      ])
+    ).start();
+  });
 
   return (
     <HeaderBar
@@ -33,10 +53,35 @@ export default function Header() {
         />
       }
       rightComponent={
-        <Image
-          source={require("../../assets/images/cambridge.png")}
-          style={{ width: 100, height: 20 }}
-        />
+        <View style={{ flex: 10, flexDirection: "row", alignItems: "center" }}>
+          {live ? (
+            <View
+              style={{
+                flexDirection: "row",
+                alignItems: "center",
+                marginRight: 20,
+              }}
+            >
+              <Text
+                style={{
+                  marginRight: 5,
+                  marginBottom: 2,
+                  color: "white",
+                }}
+              >
+                Live
+              </Text>
+              <Animated.View style={{ opacity: animVal }}>
+                <Icon name="controller-record" type="entypo" color="#f54842" />
+              </Animated.View>
+            </View>
+          ) : null}
+
+          <Image
+            source={require("../../assets/images/cambridge.png")}
+            style={{ width: 100, height: 20, marginBottom: 2 }}
+          />
+        </View>
       }
     />
   );

--- a/frontend/app/src/components/Menu.js
+++ b/frontend/app/src/components/Menu.js
@@ -286,8 +286,8 @@ export default function Menu(props) {
       case "Data Type":
         return (
           <Picker
-            value={dataType}
-            setValue={setDataType}
+            value={props.liveMode ? props.liveDataType : dataType}
+            setValue={props.liveMode ? props.setLiveDataType : setDataType}
             options={[
               { label: "Raw", value: "raw" },
               { label: "Strain", value: "str" },

--- a/frontend/app/src/components/Menu.js
+++ b/frontend/app/src/components/Menu.js
@@ -361,6 +361,11 @@ export default function Menu(props) {
     }
   }
 
+  function modelModeDisabled() {
+    const dt = props.liveMode ? props.liveDataType : props.dataType;
+    return dt !== "raw" ? [] : [0];
+  }
+
   return (
     <View
       style={props.style}
@@ -372,7 +377,7 @@ export default function Menu(props) {
       <ButtonGroup
         buttons={["Model", "Chart"]}
         selectedIndex={props.mode}
-        disabled={props.dataType !== "raw" ? [] : [0]} // Model mode only enabled for str or tmp
+        disabled={modelModeDisabled()} // Model mode only enabled for str or tmp
         onPress={(index) => props.setMode(index)}
       />
       <Divider />

--- a/frontend/app/src/components/Menu.js
+++ b/frontend/app/src/components/Menu.js
@@ -211,26 +211,28 @@ export default function Menu(props) {
     <>
       <Text>CHART OPTIONS</Text>
       {["Select Sensors"].map((element) => renderButton(element))}
-      <Button
-        title={
-          props.chartOptions.showTemperature
-            ? "Hide Outdoor Temperature"
-            : "Show Outdoor Temperature"
-        }
-        type={props.chartOptions.showTemperature ? "solid" : "outline"}
-        onPress={() =>
-          props.setChartOptions({
-            ...props.chartOptions,
-            showTemperature: !props.chartOptions.showTemperature,
-          })
-        }
-        titleStyle={{
-          fontWeight: "normal",
-          color: props.chartOptions.showTemperature
-            ? theme.colors.background
-            : theme.colors.secondary,
-        }}
-      />
+      {props.liveMode ? null : (
+        <Button
+          title={
+            props.chartOptions.showTemperature
+              ? "Hide Outdoor Temperature"
+              : "Show Outdoor Temperature"
+          }
+          type={props.chartOptions.showTemperature ? "solid" : "outline"}
+          onPress={() =>
+            props.setChartOptions({
+              ...props.chartOptions,
+              showTemperature: !props.chartOptions.showTemperature,
+            })
+          }
+          titleStyle={{
+            fontWeight: "normal",
+            color: props.chartOptions.showTemperature
+              ? theme.colors.background
+              : theme.colors.secondary,
+          }}
+        />
+      )}
       <Divider />
       <Text>LEGEND</Text>
       <View

--- a/frontend/app/src/components/Menu.js
+++ b/frontend/app/src/components/Menu.js
@@ -171,6 +171,7 @@ export default function Menu(props) {
       <ButtonGroup
         buttons={["Adaptive", "Absolute"]}
         selectedIndex={props.modelOptions.colourMode}
+        disabled={props.liveMode ? [0] : []} // Adaptive button disabled when in live mode
         onPress={(index) =>
           props.setModelOptions({
             ...props.modelOptions,
@@ -371,18 +372,18 @@ export default function Menu(props) {
       <Text>DATA OPTIONS</Text>
       <ButtonGroup
         buttons={["Live", "Historical"]}
-        selectedIndex={props.liveMode}
-        disabled={props.live ? [] : [0]} // Live mode disabled when not available
-        onPress={(index) => props.setLiveMode(index)}
+        selectedIndex={props.liveMode ? 0 : 1} // 0 = Live, 1 = Historical
+        disabled={props.live ? [] : [0]} // Live button disabled when live mode is unavailable
+        onPress={(index) =>
+          index ? props.setLiveMode(false) : props.setLiveMode(true)
+        }
       />
-      {props.liveMode ? (
+      {renderButton("Data Type")}
+      {props.liveMode ? null : (
         <>
-          {[
-            "Data Type",
-            "Averaging Window",
-            "Start Time",
-            "End Time",
-          ].map((element) => renderButton(element))}
+          {["Averaging Window", "Start Time", "End Time"].map((element) =>
+            renderButton(element)
+          )}
           <Button
             title="Refresh"
             onPress={() => {
@@ -395,7 +396,7 @@ export default function Menu(props) {
             loadingProps={{ size: 16 }}
           />
         </>
-      ) : null}
+      )}
       <Divider />
       {props.mode ? renderChartMenu() : renderModelMenu()}
       <Modal

--- a/frontend/app/src/components/Menu.js
+++ b/frontend/app/src/components/Menu.js
@@ -1,5 +1,10 @@
 import React, { useState } from "react";
-import { Platform, View, Picker as WheelPickerIOS } from "react-native";
+import {
+  Platform,
+  View,
+  Picker as WheelPickerIOS,
+  ScrollView,
+} from "react-native";
 import {
   Divider,
   Button,
@@ -16,7 +21,7 @@ import Modal from "./Modal";
 import { theme, modelColourScale } from "../utils";
 
 const MultiSelect = ({ options, setOptions }) => (
-  <>
+  <ScrollView style={{ height: "70%" }}>
     {options.map(({ name, isSelected }, index) => {
       return (
         <ListItem
@@ -34,7 +39,7 @@ const MultiSelect = ({ options, setOptions }) => (
         />
       );
     })}
-  </>
+  </ScrollView>
 );
 
 const Picker = ({ value, setValue, options }) => {

--- a/frontend/app/src/components/Menu.js
+++ b/frontend/app/src/components/Menu.js
@@ -369,23 +369,33 @@ export default function Menu(props) {
       />
       <Divider />
       <Text>DATA OPTIONS</Text>
-      {[
-        "Data Type",
-        "Averaging Window",
-        "Start Time",
-        "End Time",
-      ].map((element) => renderButton(element))}
-      <Button
-        title="Refresh"
-        onPress={() => {
-          props.refresh(dataType, averagingWindow, startTime, endTime);
-        }}
-        type="outline"
-        titleStyle={{ color: theme.colors.actionable }}
-        buttonStyle={{ borderColor: theme.colors.actionable }}
-        loading={props.isLoading}
-        loadingProps={{ size: 16 }}
+      <ButtonGroup
+        buttons={["Live", "Historical"]}
+        selectedIndex={props.liveMode}
+        disabled={props.live ? [] : [0]} // Live mode disabled when not available
+        onPress={(index) => props.setLiveMode(index)}
       />
+      {props.liveMode ? (
+        <>
+          {[
+            "Data Type",
+            "Averaging Window",
+            "Start Time",
+            "End Time",
+          ].map((element) => renderButton(element))}
+          <Button
+            title="Refresh"
+            onPress={() => {
+              props.refresh(dataType, averagingWindow, startTime, endTime);
+            }}
+            type="outline"
+            titleStyle={{ color: theme.colors.actionable }}
+            buttonStyle={{ borderColor: theme.colors.actionable }}
+            loading={props.isLoading}
+            loadingProps={{ size: 16 }}
+          />
+        </>
+      ) : null}
       <Divider />
       {props.mode ? renderChartMenu() : renderModelMenu()}
       <Modal

--- a/frontend/app/src/components/Modal.js
+++ b/frontend/app/src/components/Modal.js
@@ -8,7 +8,7 @@ import {
   Text,
   View,
   TouchableWithoutFeedback,
-  TouchableHighlight
+  TouchableHighlight,
 } from "react-native";
 
 import { theme } from "../utils";
@@ -29,14 +29,14 @@ const Header = ({ label }) => {
         borderBottomColor: BORDER_COLOR,
         borderBottomWidth: StyleSheet.hairlineWidth,
         padding: 14,
-        backgroundColor: "transparent"
+        backgroundColor: "transparent",
       }}
     >
       <Text
         style={{
           textAlign: "center",
           color: TITLE_COLOR,
-          fontSize: TITLE_FONT_SIZE
+          fontSize: TITLE_FONT_SIZE,
         }}
       >
         {label}
@@ -53,7 +53,7 @@ const ConfirmButton = ({ onPress, label }) => {
         height: 57,
         marginBottom: 0,
         justifyContent: "center",
-        backgroundColor: BACKGROUND_COLOR_LIGHT
+        backgroundColor: BACKGROUND_COLOR_LIGHT,
       }}
       underlayColor={HIGHLIGHT_COLOR_LIGHT}
       onPress={onPress}
@@ -65,7 +65,7 @@ const ConfirmButton = ({ onPress, label }) => {
           color: BUTTON_FONT_COLOR,
           fontSize: BUTTON_FONT_SIZE,
           fontWeight: "600",
-          backgroundColor: "transparent"
+          backgroundColor: "transparent",
         }}
       >
         {label}
@@ -86,9 +86,9 @@ export default function Modal(props) {
     Animated.timing(animVal, {
       easing: Easing.inOut(Easing.quad),
       // Using native driver in the modal makes the content flash
-      useNativeDriver: false,
+      useNativeDriver: true,
       duration: 300,
-      toValue: 1
+      toValue: 1,
     }).start();
   };
 
@@ -96,9 +96,9 @@ export default function Modal(props) {
     Animated.timing(animVal, {
       easing: Easing.inOut(Easing.quad),
       // Using native driver in the modal makes the content flash
-      useNativeDriver: false,
+      useNativeDriver: true,
       duration: 300,
-      toValue: 0
+      toValue: 0,
     }).start(() => {
       setIsVisible(false);
     });
@@ -123,8 +123,8 @@ export default function Modal(props) {
             backgroundColor: "black",
             opacity: animVal.interpolate({
               inputRange: [0, 1],
-              outputRange: [0, 0.4]
-            })
+              outputRange: [0, 0.4],
+            }),
           }}
         />
       </TouchableWithoutFeedback>
@@ -142,10 +142,10 @@ export default function Modal(props) {
                 translateY: animVal.interpolate({
                   inputRange: [0, 1],
                   outputRange: [height, 0],
-                  extrapolate: "clamp"
-                })
-              }
-            ]
+                  extrapolate: "clamp",
+                }),
+              },
+            ],
           }}
           pointerEvents="box-none"
         >
@@ -155,7 +155,7 @@ export default function Modal(props) {
               marginBottom: 8,
               overflow: "hidden",
               backgroundColor: BACKGROUND_COLOR_LIGHT,
-              paddingHorizontal: 12
+              paddingHorizontal: 12,
             }}
           >
             <Header label={label} />

--- a/frontend/app/src/components/Modal.js
+++ b/frontend/app/src/components/Modal.js
@@ -85,7 +85,6 @@ export default function Modal(props) {
     setIsVisible(true);
     Animated.timing(animVal, {
       easing: Easing.inOut(Easing.quad),
-      // Using native driver in the modal makes the content flash
       useNativeDriver: true,
       duration: 300,
       toValue: 1,
@@ -95,7 +94,6 @@ export default function Modal(props) {
   hide = () => {
     Animated.timing(animVal, {
       easing: Easing.inOut(Easing.quad),
-      // Using native driver in the modal makes the content flash
       useNativeDriver: true,
       duration: 300,
       toValue: 0,

--- a/frontend/app/src/components/Model.js
+++ b/frontend/app/src/components/Model.js
@@ -38,9 +38,13 @@ export default function Model(props) {
   };
 
   useEffect(() => {
-    if (props.data.length) {
+    const sample = props.liveMode
+      ? props.liveData[props.liveData.length - 1]
+      : props.data[index];
+
+    if (sample) {
       const colours = Object.fromEntries(
-        Object.entries(props.data[index]).map(([sensor, value]) => [
+        Object.entries(sample).map(([sensor, value]) => [
           sensor,
           mapColour(value),
         ])
@@ -49,6 +53,8 @@ export default function Model(props) {
     }
   }, [
     props.data,
+    props.liveMode,
+    props.liveData,
     props.modelOptions.colourMode,
     props.modelOptions.scale,
     index,
@@ -92,32 +98,34 @@ export default function Model(props) {
             {props.children({ rotation, zoom, sensorColours })}
           </Suspense>
         </Canvas>
-        <View
-          style={{
-            position: "absolute",
-            bottom: 0,
-            left: 0,
-            right: 0,
-            height: 80,
-            marginHorizontal: 35,
-          }}
-        >
-          <Slider
-            value={index}
-            onValueChange={(value) => setIndex(value)}
-            maximumValue={props.data.length ? props.data.length - 1 : 0}
-            step={1}
-            thumbStyle={{ backgroundColor: theme.colors.primary }}
-          />
-          <XAxis
-            style={{ height: 25 }}
-            data={props.data}
-            xAccessor={({ item }) => item.timestamp}
-            formatLabel={formatTimestampLabel}
-            svg={{ fontSize: 10, fill: theme.colors.primary }}
-            numberOfTicks={5}
-          />
-        </View>
+        {props.liveMode ? null : (
+          <View
+            style={{
+              position: "absolute",
+              bottom: 0,
+              left: 0,
+              right: 0,
+              height: 80,
+              marginHorizontal: 35,
+            }}
+          >
+            <Slider
+              value={index}
+              onValueChange={(value) => setIndex(value)}
+              maximumValue={props.data.length ? props.data.length - 1 : 0}
+              step={1}
+              thumbStyle={{ backgroundColor: theme.colors.primary }}
+            />
+            <XAxis
+              style={{ height: 25 }}
+              data={props.data}
+              xAccessor={({ item }) => item.timestamp}
+              formatLabel={formatTimestampLabel}
+              svg={{ fontSize: 10, fill: theme.colors.primary }}
+              numberOfTicks={5}
+            />
+          </View>
+        )}
       </View>
     </PinchGestureHandler>
   );

--- a/frontend/app/src/components/Screen.js
+++ b/frontend/app/src/components/Screen.js
@@ -21,6 +21,7 @@ export default function Screen(props) {
   const [liveMode, setLiveMode] = useState(false); // true for Live, false for Historical
   const [dataRange, setDataRange] = useState([]);
   const [dataType, setDataType] = useState("str");
+  const [liveDataType, setLiveDataType] = useState("str");
   const [isLoading, setIsLoading] = useState(false);
   const [chartOptions, setChartOptions] = useState({
     sensors: [], // [{ name: sensorName, isSelected: true}, ... }]
@@ -52,7 +53,7 @@ export default function Screen(props) {
   useEffect(() => {
     if (liveMode) {
       let ws = new WebSocket(
-        `ws://129.169.72.175/fbg/live-data/?data-type=${dataType}`
+        `ws://129.169.72.175/fbg/live-data/?data-type=${liveDataType}`
       );
       ws.onmessage = (event) => {
         const message = event.data;
@@ -77,7 +78,7 @@ export default function Screen(props) {
         setLiveData((liveData) => []);
       };
     }
-  }, [liveMode, dataType, props.packageServerName]);
+  }, [liveMode, liveDataType, props.packageServerName]);
 
   async function refresh(dataType, averagingWindow, startTime, endTime) {
     setIsLoading(true);
@@ -179,6 +180,8 @@ export default function Screen(props) {
         liveMode={liveMode}
         setLiveMode={setLiveMode}
         dataType={dataType}
+        liveDataType={liveDataType}
+        setLiveDataType={setLiveDataType}
         dataRange={dataRange}
         isLoading={isLoading}
         refresh={refresh}

--- a/frontend/app/src/components/Screen.js
+++ b/frontend/app/src/components/Screen.js
@@ -38,11 +38,12 @@ export default function Screen(props) {
   useEffect(() => {
     const live = liveStatus.packages.includes(props.packageServerName);
     setLive(live);
-    if (live) {
-      // Set to absolute colour scale and showTemperature false when pacakge is live
-      setModelOptions({ ...modelOptions, colourMode: 1 });
+    if (liveMode) {
+      // Set to absolute colour scale and showTemperature false when pacakge is in live mode
+      setModelOptions({ ...modelOptions, colourMode: 1, scale: [-200, 200] });
       setChartOptions({ ...chartOptions, showTemperature: false });
-    } else {
+    }
+    if (!live) {
       // Set to historical mode when package is not live
       setLiveMode(false);
     }

--- a/frontend/app/src/components/Screen.js
+++ b/frontend/app/src/components/Screen.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useContext, useEffect } from "react";
 import { View } from "react-native";
 
 import Menu from "./Menu";
@@ -10,11 +10,14 @@ import {
   theme,
   chartColours,
   modelColourScale,
+  LiveStatusContext,
 } from "../utils";
 
 export default function Screen(props) {
   const [data, setData] = useState([]);
   const [mode, setMode] = useState(0); // 0 for Model, 1 for Chart
+  const [live, setLive] = useState(false);
+  const [liveMode, setLiveMode] = useState(1); // 0 for Live, 1 for Historical
   const [dataRange, setDataRange] = useState([]);
   const [dataType, setDataType] = useState("str");
   const [isLoading, setIsLoading] = useState(false);
@@ -28,6 +31,17 @@ export default function Screen(props) {
     colourMode: 0, // 0 = adaptive
     scale: [0, 0],
   });
+
+  const { packages: livePackages } = useContext(LiveStatusContext);
+
+  useEffect(() => {
+    const live = livePackages.includes(props.packageServerName);
+    setLive(live);
+    if (!live) {
+      // Set to historical mode when package is not live
+      setLiveMode(1);
+    }
+  }, [livePackages]);
 
   async function refresh(dataType, averagingWindow, startTime, endTime) {
     setIsLoading(true);
@@ -113,6 +127,9 @@ export default function Screen(props) {
         }}
         mode={mode}
         setMode={setMode}
+        live={live}
+        liveMode={liveMode}
+        setLiveMode={setLiveMode}
         dataType={dataType}
         dataRange={dataRange}
         isLoading={isLoading}

--- a/frontend/app/src/components/Screen.js
+++ b/frontend/app/src/components/Screen.js
@@ -41,14 +41,18 @@ export default function Screen(props) {
     setLive(live);
     if (liveMode) {
       // Set to absolute colour scale and showTemperature false when pacakge is in live mode
-      setModelOptions({ ...modelOptions, colourMode: 1, scale: [-200, 200] });
+      setModelOptions({
+        ...modelOptions,
+        colourMode: 1,
+        scale: modelColourScale[liveDataType],
+      });
       setChartOptions({ ...chartOptions, showTemperature: false });
     }
     if (!live) {
       // Set to historical mode when package is not live
       setLiveMode(false);
     }
-  }, [liveStatus, props.packageServerName]);
+  }, [liveStatus, liveDataType, props.packageServerName]);
 
   useEffect(() => {
     if (liveMode) {

--- a/frontend/app/src/components/Screen.js
+++ b/frontend/app/src/components/Screen.js
@@ -47,6 +47,10 @@ export default function Screen(props) {
         scale: modelColourScale[liveDataType],
       });
       setChartOptions({ ...chartOptions, showTemperature: false });
+      if (liveDataType === "raw") {
+        // Set to chart mode when liveDataType is raw
+        setMode(1);
+      }
     }
     if (!live) {
       // Set to historical mode when package is not live

--- a/frontend/app/src/components/Screen.js
+++ b/frontend/app/src/components/Screen.js
@@ -63,6 +63,7 @@ export default function Screen(props) {
         const sensorNames = Object.keys(readings);
         setChartOptions({
           ...chartOptions,
+          showTemperature: false,
           sensors: sensorNames.map((sensorName, index) => ({
             name: sensorName,
             isSelected: index < 3, // By default display only the first three sensors on the chart

--- a/frontend/app/src/models/utils.js
+++ b/frontend/app/src/models/utils.js
@@ -2,30 +2,15 @@ import React from "react";
 
 /*
 This function return a Three.js material coloured according to the map
-of sensor colours and a given list of sensor names. The function will try accessing
-the map with each name until it finds a match, at which point it will return a material
-of that colour.
-
-In this way, a Three.js object which represents both a strain and a temperature sensor
-can be coloured just by supplying the names used in both cases to the sensorNames array.
-This avoids having to check the dataType, and allows us to pass in multiple alternative
-names for each sensor in case they change in a future version of the NRFIS API.
+of sensor colours and a given sensor name.
 */
-
-export function renderSensorColour(sensorColours, sensorNames) {
-  sensorNames = Array.isArray(sensorNames) ? sensorNames : [sensorNames]; // To allow specifying a single sensor name not as an array
-
-  for (const sensorName of sensorNames) {
-    if (sensorColours[sensorName]) {
-      return (
-        <meshBasicMaterial
-          attach="material"
-          color={sensorColours[sensorName]}
-        />
-      );
-    }
-  }
-  return <meshBasicMaterial attach="material" transparent={true} opacity={0} />;
+export function renderSensorColour(sensorColours, sensorName) {
+  return (
+    <meshBasicMaterial
+      attach="material"
+      color={sensorColours[sensorName] ? sensorColours[sensorName] : "white"}
+    />
+  );
 }
 
 export function renderSensor(sensorColours, sensorName, position, size) {

--- a/frontend/app/src/screens/SteelFrameScreen.js
+++ b/frontend/app/src/screens/SteelFrameScreen.js
@@ -5,7 +5,7 @@ import { SteelFrameModel } from "../models";
 
 export default function SteelFrameScreen() {
   return (
-    <Screen packageURL="steel-frame">
+    <Screen packageURL="steel-frame" packageServerName="SteelFrame">
       {(props) => <SteelFrameModel {...props} />}
     </Screen>
   );

--- a/frontend/app/src/screens/StrongFloorScreen.js
+++ b/frontend/app/src/screens/StrongFloorScreen.js
@@ -5,7 +5,7 @@ import { StrongFloorModel } from "../models";
 
 export default function StrongFloorScreen() {
   return (
-    <Screen packageURL="strong-floor">
+    <Screen packageURL="strong-floor" packageServerName="StrongFloor">
       {(props) => <StrongFloorModel {...props} />}
     </Screen>
   );

--- a/frontend/app/src/utils/LiveStatusContext.js
+++ b/frontend/app/src/utils/LiveStatusContext.js
@@ -1,0 +1,5 @@
+import React from "react";
+
+const LiveStatusContext = React.createContext();
+
+export default LiveStatusContext;

--- a/frontend/app/src/utils/fetchData.js
+++ b/frontend/app/src/utils/fetchData.js
@@ -60,3 +60,16 @@ export async function fetchTemperatureData(startTime, endTime) {
   }
   return temperatureData;
 }
+
+export async function fetchLiveStatus() {
+  try {
+    const response = await fetch("http://129.169.72.175/fbg/live-status/", {
+      method: "GET",
+      headers: { "media-type": "application/json" },
+    });
+    const data = await response.json();
+    return data;
+  } catch (error) {
+    console.error(error);
+  }
+}

--- a/frontend/app/src/utils/fetchData.js
+++ b/frontend/app/src/utils/fetchData.js
@@ -62,14 +62,10 @@ export async function fetchTemperatureData(startTime, endTime) {
 }
 
 export async function fetchLiveStatus() {
-  try {
-    const response = await fetch("http://129.169.72.175/fbg/live-status/", {
-      method: "GET",
-      headers: { "media-type": "application/json" },
-    });
-    const data = await response.json();
-    return data;
-  } catch (error) {
-    console.error(error);
-  }
+  const response = await fetch("http://129.169.72.175/fbg/live-status/", {
+    method: "GET",
+    headers: { "media-type": "application/json" },
+  });
+  const data = await response.json();
+  return data;
 }

--- a/frontend/app/src/utils/index.js
+++ b/frontend/app/src/utils/index.js
@@ -1,4 +1,9 @@
-export { default as fetchData, fetchTemperatureData } from "./fetchData";
+export {
+  default as fetchData,
+  fetchTemperatureData,
+  fetchLiveStatus,
+} from "./fetchData";
 export { default as theme } from "./theme";
 export { default as chartColours } from "./chartColours";
 export { default as modelColourScale } from "./modelColourScale";
+export { default as LiveStatusContext } from "./LiveStatusContext";

--- a/frontend/app/src/utils/theme.js
+++ b/frontend/app/src/utils/theme.js
@@ -43,7 +43,7 @@ const theme = {
       fontSize: 16,
       fontFamily: font,
       fontWeight: "normal",
-      color: colors.primary,
+      color: colors.secondary,
     },
     selectedTextStyle: { fontWeight: "500" },
     containerStyle: { borderColor: colors.primary, borderWidth: 1 },


### PR DESCRIPTION
- Repeatedly fetch the live recording status of the data collection system every 5s, and pass it down to the rest of the app via a React Context. This is consumed by the Header to display a blinking red recording icon when the system is live, and also by each package screen to determine whether that package is live.
- The menu displays a toggle to switch between live and historical data, enabled only if live data is available.
- Data is then live-streamed to each screen if the live mode is toggled on, by opening a web socket to the NRFIS API `fbg/live-data/?data-type=...` web socket endpoint. The screen holds a buffer of up to 30 previous live data-points. The web socket is closed when the live data type or live mode is changed, or when the screen component is unmounted, by way of a clean up function returned in useEffect. When the web socket is closed the live data state is also cleared to avoid inconsistent mixed type data.
- This live data is then passed to the model and chart components, which render the following in live mode:
    - Model: renders the most recent live reading on the model, with no slider to change the time. The colour scale is set to absolute in this mode.
    - Chart: renders the current live-data on a chart of width 35 data-points. This results in an oscilloscope style trace which resets every 30 data-points, since the live data state is cleared every 30 data-points. Outdoor temperature data is switched off in this mode.
- Wrapped the MultiSelect selector component in a ScrollView for correct sizing of the modal and scrolling through long lists of sensors.
