### PR TITLE
General improvements

### DIFF
--- a/frontend/app/App.js
+++ b/frontend/app/App.js
@@ -48,8 +48,8 @@ export default function App() {
             }}
           >
             <Tab.Screen name="Steel Frame" component={SteelFrameScreen} />
-            <Tab.Screen name="Strong Floor" component={StrongFloorScreen} />
             <Tab.Screen name="Basement" component={BasementScreen} />
+            <Tab.Screen name="Strong Floor" component={StrongFloorScreen} />
           </Tab.Navigator>
         </NavigationContainer>
       </LiveStatusContext.Provider>

--- a/frontend/app/src/components/Chart.js
+++ b/frontend/app/src/components/Chart.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { View } from "react-native";
-import { Text } from "react-native-elements";
+import { Button, Text } from "react-native-elements";
 import { Circle, G, Rect, Line, Text as SVGText } from "react-native-svg";
 import { LineChart, Grid, YAxis, XAxis } from "react-native-svg-charts";
 import * as D3 from "d3-shape";
@@ -274,6 +274,20 @@ export default function Chart(props) {
           contentInset={contentInset}
           svg={{ fontSize: 10, fill: theme.colors.primary }}
           numberOfTicks={5}
+        />
+        <Button
+          containerStyle={{
+            position: "absolute",
+            right: 0,
+            margin: 11,
+          }}
+          type="outline"
+          title="Reset"
+          onPress={() => {
+            setMinX(timestamps[0]);
+            setMaxX(timestamps[timestamps.length - 1]);
+            setBaseRange([timestamps[0], timestamps[timestamps.length - 1]]);
+          }}
         />
       </View>
     </PinchGestureHandler>

--- a/frontend/app/src/components/Chart.js
+++ b/frontend/app/src/components/Chart.js
@@ -7,7 +7,7 @@ import * as D3 from "d3-shape";
 import { State, PinchGestureHandler } from "react-native-gesture-handler";
 
 import formatTimestampLabel from "./utils";
-import { theme } from "../utils";
+import { theme, labels } from "../utils";
 
 const contentInset = { top: 10, bottom: 10, left: 10, right: 10 };
 
@@ -69,7 +69,7 @@ const Decorators = ({ x, y, data: datasets, timestamps }) =>
   );
 
 export default function Chart(props) {
-  const { data, liveData, liveMode, chartOptions } = props;
+  const { data, liveData, liveMode, screenState, chartOptions } = props;
 
   const [width, setWidth] = useState(0);
   const [datasets, setDatasets] = useState([]);
@@ -174,7 +174,7 @@ export default function Chart(props) {
       onHandlerStateChange={handleStateChange}
     >
       <View
-        style={{ flex: 1, padding: 15 }}
+        style={{ flex: 1, paddingVertical: 15, paddingRight: 5 }}
         onMoveShouldSetResponder={(_) => true}
         onResponderMove={(event) => handleResponderMove(event)}
       >
@@ -184,18 +184,35 @@ export default function Chart(props) {
             setWidth(event.nativeEvent.layout.width);
           }}
         >
-          <YAxis
-            style={{ width: 35 }}
-            data={datasets.reduce(
-              (acc, dataset) => acc.concat(dataset.data),
-              []
-            )}
-            formatLabel={(value) => value.toPrecision(4)}
-            contentInset={contentInset}
-            svg={{ fontSize: 10, fill: theme.colors.primary }}
-            numberOfTicks={10}
-          />
-          <View style={{ flex: 1, marginHorizontal: 15 }}>
+          <View style={{ width: 80, flexDirection: "row", marginRight: 10 }}>
+            <Text
+              style={{
+                fontWeight: "bold",
+                color: theme.colors.primary,
+                alignSelf: "center",
+              }}
+            >
+              {liveMode
+                ? labels["Data Type"].find(
+                    (element) => element.value === screenState.liveDataType
+                  ).unit
+                : labels["Data Type"].find(
+                    (element) => element.value === screenState.dataType
+                  ).unit}
+            </Text>
+            <YAxis
+              style={{ flex: 1 }}
+              data={datasets.reduce(
+                (acc, dataset) => acc.concat(dataset.data),
+                []
+              )}
+              formatLabel={(value) => value.toPrecision(4)}
+              contentInset={contentInset}
+              svg={{ fontSize: 10, fill: theme.colors.primary }}
+              numberOfTicks={10}
+            />
+          </View>
+          <View style={{ flex: 1 }}>
             {chartOptions.showTemperature ? (
               <LineChart
                 style={{
@@ -241,7 +258,7 @@ export default function Chart(props) {
                 style={{ flex: 1 }}
                 data={chartOptions.temperatureData}
                 yAccessor={({ item }) => item.temperature}
-                formatLabel={(value) => value.toPrecision(4)}
+                formatLabel={(value) => value.toPrecision(2)}
                 contentInset={contentInset}
                 svg={{ fontSize: 10, fill: theme.colors.primary }}
                 numberOfTicks={10}
@@ -250,7 +267,7 @@ export default function Chart(props) {
           </View>
         </View>
         <XAxis
-          style={{ height: 25, marginHorizontal: 35, marginTop: 10 }}
+          style={{ height: 25, marginLeft: 90, marginRight: 35, marginTop: 10 }}
           data={[minX, maxX]}
           xAccessor={({ item }) => item}
           formatLabel={liveMode ? (value) => value : formatTimestampLabel}

--- a/frontend/app/src/components/Chart.js
+++ b/frontend/app/src/components/Chart.js
@@ -184,7 +184,7 @@ export default function Chart(props) {
             setWidth(event.nativeEvent.layout.width);
           }}
         >
-          <View style={{ width: 80, flexDirection: "row", marginRight: 10 }}>
+          <View style={{ width: 82, flexDirection: "row", marginRight: 10 }}>
             <Text
               style={{
                 fontWeight: "bold",

--- a/frontend/app/src/components/Header.js
+++ b/frontend/app/src/components/Header.js
@@ -13,7 +13,7 @@ export default function Header() {
   opacity = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
-    Animated.loop(
+    const animation = Animated.loop(
       Animated.sequence([
         Animated.timing(opacity, {
           toValue: 0,
@@ -27,8 +27,12 @@ export default function Header() {
           useNativeDriver: true,
         }),
       ])
-    ).start();
-  });
+    );
+    if (live) {
+      animation.start();
+    }
+    return () => animation.stop();
+  }, [live]);
 
   return (
     <>
@@ -60,32 +64,30 @@ export default function Header() {
           <View
             style={{ flex: 10, flexDirection: "row", alignItems: "center" }}
           >
-            {live ? (
-              <View
+            <View
+              style={{
+                flexDirection: "row",
+                alignItems: "center",
+                marginRight: 20,
+              }}
+            >
+              <Text
                 style={{
-                  flexDirection: "row",
-                  alignItems: "center",
-                  marginRight: 20,
+                  marginRight: 5,
+                  marginBottom: 2,
+                  color: "white",
                 }}
               >
-                <Text
-                  style={{
-                    marginRight: 5,
-                    marginBottom: 2,
-                    color: "white",
-                  }}
-                >
-                  Live
-                </Text>
-                <Animated.View style={{ opacity: opacity }}>
-                  <Icon
-                    name="controller-record"
-                    type="entypo"
-                    color="#f54842"
-                  />
-                </Animated.View>
-              </View>
-            ) : null}
+                {live ? "Live" : "Not live"}
+              </Text>
+              <Animated.View style={{ opacity: opacity }}>
+                <Icon
+                  name="controller-record"
+                  type="entypo"
+                  color={live ? "#f54842" : theme.colors.primary}
+                />
+              </Animated.View>
+            </View>
             <Icon
               containerStyle={{ marginHorizontal: 20 }}
               name="help-with-circle"

--- a/frontend/app/src/components/Header.js
+++ b/frontend/app/src/components/Header.js
@@ -89,7 +89,7 @@ export default function Header() {
               </Animated.View>
             </View>
             <Icon
-              containerStyle={{ marginHorizontal: 20 }}
+              containerStyle={{ marginRight: 20 }}
               name="help-with-circle"
               type="entypo"
               color="white"

--- a/frontend/app/src/components/Header.js
+++ b/frontend/app/src/components/Header.js
@@ -1,10 +1,13 @@
-import React, { useContext, useEffect, useRef } from "react";
+import React, { useState, useContext, useEffect, useRef } from "react";
 import { View, Image, Text, Animated } from "react-native";
 import { Header as HeaderBar, Icon } from "react-native-elements";
 
+import HelpOverlay from "./HelpOverlay";
 import { theme, LiveStatusContext } from "../utils";
 
 export default function Header() {
+  const [showHelp, setShowHelp] = useState(false);
+
   const { live } = useContext(LiveStatusContext);
 
   opacity = useRef(new Animated.Value(1)).current;
@@ -28,61 +31,77 @@ export default function Header() {
   });
 
   return (
-    <HeaderBar
-      containerStyle={{
-        height: 70,
-        paddingVertical: 20,
-        paddingHorizontal: 20,
-        borderBottomColor: theme.colors.secondary,
-      }}
-      statusBarProps={{
-        hidden: true,
-      }}
-      placement="left"
-      backgroundColor={theme.colors.secondary}
-      leftComponent={
-        <Image
-          source={require("../../assets/images/logo.png")}
-          style={{ width: 75, height: 55 }}
-        />
-      }
-      centerComponent={
-        <Image
-          source={require("../../assets/images/title.png")}
-          style={{ width: 60, height: 10 }}
-        />
-      }
-      rightComponent={
-        <View style={{ flex: 10, flexDirection: "row", alignItems: "center" }}>
-          {live ? (
-            <View
-              style={{
-                flexDirection: "row",
-                alignItems: "center",
-                marginRight: 20,
-              }}
-            >
-              <Text
+    <>
+      <HeaderBar
+        containerStyle={{
+          height: 70,
+          paddingVertical: 20,
+          paddingHorizontal: 20,
+          borderBottomColor: theme.colors.secondary,
+        }}
+        statusBarProps={{
+          hidden: true,
+        }}
+        placement="left"
+        backgroundColor={theme.colors.secondary}
+        leftComponent={
+          <Image
+            source={require("../../assets/images/logo.png")}
+            style={{ width: 75, height: 55 }}
+          />
+        }
+        centerComponent={
+          <Image
+            source={require("../../assets/images/title.png")}
+            style={{ width: 60, height: 10 }}
+          />
+        }
+        rightComponent={
+          <View
+            style={{ flex: 10, flexDirection: "row", alignItems: "center" }}
+          >
+            {live ? (
+              <View
                 style={{
-                  marginRight: 5,
-                  marginBottom: 2,
-                  color: "white",
+                  flexDirection: "row",
+                  alignItems: "center",
+                  marginRight: 20,
                 }}
               >
-                Live
-              </Text>
-              <Animated.View style={{ opacity: opacity }}>
-                <Icon name="controller-record" type="entypo" color="#f54842" />
-              </Animated.View>
-            </View>
-          ) : null}
-
-          <Image
-            source={require("../../assets/images/cambridge.png")}
-            style={{ width: 100, height: 20, marginBottom: 2 }}
-          />
-        </View>
-      }
-    />
+                <Text
+                  style={{
+                    marginRight: 5,
+                    marginBottom: 2,
+                    color: "white",
+                  }}
+                >
+                  Live
+                </Text>
+                <Animated.View style={{ opacity: opacity }}>
+                  <Icon
+                    name="controller-record"
+                    type="entypo"
+                    color="#f54842"
+                  />
+                </Animated.View>
+              </View>
+            ) : null}
+            <Icon
+              containerStyle={{ marginHorizontal: 20 }}
+              name="help-with-circle"
+              type="entypo"
+              color="white"
+              underlayColor={"transparent"}
+              onPress={() => setShowHelp(!showHelp)}
+            />
+            <Image
+              source={require("../../assets/images/cambridge.png")}
+              style={{ width: 100, height: 20, marginBottom: 2 }}
+            />
+          </View>
+        }
+      />
+      <HelpOverlay isActive={showHelp} setIsActive={setShowHelp} />
+    </>
   );
 }

--- a/frontend/app/src/components/HelpOverlay.js
+++ b/frontend/app/src/components/HelpOverlay.js
@@ -1,0 +1,190 @@
+import React, { useState, useEffect, useRef } from "react";
+import {
+  View,
+  Modal,
+  Animated,
+  TouchableWithoutFeedback,
+  Easing,
+  Dimensions,
+} from "react-native";
+import { Text, Icon } from "react-native-elements";
+
+const HelpText = ({ children, style }) => (
+  <View
+    style={{ flex: 1, flexDirection: "row", alignItems: "center", ...style }}
+  >
+    <Text style={{ color: "white" }}>{children}</Text>
+    <Icon name="long-arrow-right" type="font-awesome" color="white" size={30} />
+  </View>
+);
+
+export default function HelpOverlay({ isActive, setIsActive }) {
+  const [isVisible, setIsVisible] = useState(false);
+
+  const helpOverlayOpacity = useRef(new Animated.Value(0)).current;
+
+  show = () => {
+    setIsVisible(true);
+    Animated.timing(helpOverlayOpacity, {
+      easing: Easing.inOut(Easing.quad),
+      useNativeDriver: true,
+      duration: 300,
+      toValue: 1,
+    }).start();
+  };
+
+  hide = () => {
+    Animated.timing(helpOverlayOpacity, {
+      easing: Easing.inOut(Easing.quad),
+      useNativeDriver: true,
+      duration: 300,
+      toValue: 0,
+    }).start(() => {
+      setIsVisible(false);
+    });
+  };
+
+  useEffect(() => {
+    if (isActive) {
+      show();
+    } else {
+      hide();
+    }
+  }, [isActive]);
+
+  return (
+    <Modal transparent animationType="none" visible={isVisible}>
+      <>
+        <Animated.View
+          style={{
+            width: Dimensions.get("window").width,
+            height: Dimensions.get("window").height,
+            position: "absolute",
+            backgroundColor: "black",
+            opacity: helpOverlayOpacity.interpolate({
+              inputRange: [0, 1],
+              outputRange: [0, 0.4],
+            }),
+          }}
+        />
+        <TouchableWithoutFeedback onPress={() => setIsActive(false)}>
+          <Animated.View
+            style={{
+              flex: 1,
+              opacity: helpOverlayOpacity,
+            }}
+          >
+            <View
+              style={{
+                height: 70,
+                flexDirection: "column",
+              }}
+            >
+              <HelpText style={{ alignSelf: "flex-end", marginRight: 300 }}>
+                Shows whether the system is currently recording
+              </HelpText>
+            </View>
+            <View style={{ flex: 1, flexDirection: "row" }}>
+              <View
+                style={{
+                  flex: 3,
+                  alignItems: "flex-end",
+                }}
+              >
+                <HelpText
+                  style={{
+                    flex: 1,
+                    marginHorizontal: 20,
+                  }}
+                >
+                  Model mode renders a 3D model of the building with coloured
+                  sensors, "Chart" mode renders a scatter plot of the data
+                </HelpText>
+                <HelpText
+                  style={{
+                    flex: 2,
+                    marginHorizontal: 20,
+                  }}
+                >
+                  Select the data you wish to visualise
+                </HelpText>
+                <View
+                  style={{
+                    flex: 6,
+                    padding: 20,
+                    marginHorizontal: 20,
+                    marginBottom: 20,
+                    backgroundColor: "white",
+                    borderRadius: 4,
+                  }}
+                >
+                  <Text>
+                    The National Research Facility for Infrastructure Sensing
+                    (NRFIS) is a new state of the art research facility hosted
+                    by the University of Cambridge. Housed in the new Civil
+                    Engineering Building, NRFIS brings together specialist
+                    engineering facilities and sensor development capabilities
+                    under one roof. It offers an interdisciplinary centre for
+                    cutting edge research to explore the development and
+                    application of novel sensor systems at a range of scales.
+                  </Text>
+                  <Text>
+                    The building is instrumented with six sensor packages, from
+                    the roof to the foundations. The sensors are an integral
+                    part of research being undertaken in Civil Engineering at
+                    Cambridge and link closely to the Centre for Smart
+                    Infrastructure and Construction (CSIC), also at the
+                    University of Cambridge. We are developing the technologies
+                    to display, store, interpret, and visualise these data
+                    streams. This information will be used to understand the
+                    performance of the new research facility and assess this
+                    performance against the predictions made during design. By
+                    examining any differences, we aim to understand performance,
+                    and help improve future design.
+                  </Text>
+                  <Text>
+                    This app serves as an interface into the building's fibre
+                    optic FBG sensor monitoring system, which continuously
+                    records strain and temperature change in the steel frame,
+                    basement and strong floor. It offers a platform for
+                    visualising the historical archive of data on interactive 3D
+                    models and scatter plots, as well as real-time data when the
+                    system is currently recording.
+                  </Text>
+                </View>
+                <View
+                  style={{
+                    flex: 2,
+                    padding: 20,
+                    marginHorizontal: 20,
+                    marginBottom: 90,
+                    backgroundColor: "white",
+                    borderRadius: 4,
+                  }}
+                >
+                  <Text>Sensor naming conventions:</Text>
+                  <Text>
+                    Steel Frame: [BM/CL = Beam/Column] - [DX = Grid No.] - [X =
+                    Floor] [a/b = Top/Bottom Flange]
+                  </Text>
+                  <Text>
+                    Basement + Strong Floor: [EW/NS = East-West/North-South] -
+                    [Str/Tmp = Strain/Temperature] - [bot/top = Bottom/Top] [X =
+                    Index on Cable]
+                  </Text>
+                </View>
+              </View>
+              <View
+                style={{
+                  flex: 1,
+                  minWidth: 100,
+                  paddingVertical: 20,
+                }}
+              />
+            </View>
+          </Animated.View>
+        </TouchableWithoutFeedback>
+      </>
+    </Modal>
+  );
+}

--- a/frontend/app/src/components/Menu.js
+++ b/frontend/app/src/components/Menu.js
@@ -224,7 +224,7 @@ export default function Menu(props) {
   const renderChartMenu = () => (
     <>
       <Text>CHART OPTIONS</Text>
-      {["Select Sensors"].map((element) => renderButton(element))}
+      {renderButton("Select Sensors")}
       {props.liveMode ? null : (
         <Button
           title={

--- a/frontend/app/src/components/Menu.js
+++ b/frontend/app/src/components/Menu.js
@@ -282,10 +282,12 @@ export default function Menu(props) {
         {props.chartOptions.showTemperature ? (
           <ListItem
             containerStyle={{
-              width: "50%",
+              minWidth: 150,
+              maxWidth: 250,
               padding: 0,
+              marginHorizontal: 10,
             }}
-            title="OUTDOOR TEMP."
+            title="OUTDOOR TEMPERATURE"
             titleStyle={{ fontSize: 12 }}
             rightIcon={{
               name: "minus",

--- a/frontend/app/src/components/Menu.js
+++ b/frontend/app/src/components/Menu.js
@@ -21,7 +21,7 @@ import Modal from "./Modal";
 import { theme, modelColourScale } from "../utils";
 
 const MultiSelect = ({ options, setOptions }) => (
-  <ScrollView style={{ height: "70%" }}>
+  <ScrollView style={{ maxHeight: "100%" }}>
     {options.map(({ name, isSelected }, index) => {
       return (
         <ListItem
@@ -243,8 +243,10 @@ export default function Menu(props) {
       <View
         style={{
           flex: 1,
+          flexDirection: "row",
           flexWrap: "wrap",
           alignItems: "flex-start",
+          marginBottom: 20,
         }}
       >
         {props.chartOptions.sensors
@@ -253,8 +255,10 @@ export default function Menu(props) {
             <ListItem
               key={name}
               containerStyle={{
-                width: "50%",
+                minWidth: 150,
+                maxWidth: 250,
                 padding: 0,
+                marginHorizontal: 10,
               }}
               title={name}
               titleStyle={{ fontSize: 12 }}
@@ -367,7 +371,7 @@ export default function Menu(props) {
   }
 
   return (
-    <View
+    <ScrollView
       style={props.style}
       onLayout={(event) => {
         setWidth(event.nativeEvent.layout.width);
@@ -432,6 +436,6 @@ export default function Menu(props) {
       >
         {(dialogProps) => renderDialogSelector(shownElement, dialogProps)}
       </Dialog>
-    </View>
+    </ScrollView>
   );
 }

--- a/frontend/app/src/components/Modal.js
+++ b/frontend/app/src/components/Modal.js
@@ -131,7 +131,6 @@ export default function Modal(props) {
           style={{
             flex: 1,
             width: width,
-
             justifyContent: "flex-end",
             alignSelf: "flex-end",
             padding: 10,
@@ -149,6 +148,7 @@ export default function Modal(props) {
         >
           <View
             style={{
+              maxHeight: height - 12,
               borderRadius: BORDER_RADIUS,
               marginBottom: 8,
               overflow: "hidden",

--- a/frontend/app/src/components/Model.js
+++ b/frontend/app/src/components/Model.js
@@ -2,7 +2,7 @@ import React, { Suspense, useState, useEffect } from "react";
 import { View, Platform } from "react-native";
 import * as THREE from "three";
 import { Canvas } from "react-three-fiber";
-import { Slider } from "react-native-elements";
+import { Slider, Button } from "react-native-elements";
 import { State, PinchGestureHandler } from "react-native-gesture-handler";
 import { XAxis } from "react-native-svg-charts";
 
@@ -98,6 +98,20 @@ export default function Model(props) {
             {props.children({ rotation, zoom, sensorColours })}
           </Suspense>
         </Canvas>
+        <Button
+          containerStyle={{
+            position: "absolute",
+            right: 0,
+            margin: 11,
+          }}
+          type="outline"
+          title="Reset"
+          onPress={() => {
+            setRotation(new THREE.Euler(0, 0));
+            setZoom(1);
+            setBaseZoom(1);
+          }}
+        />
         {props.liveMode ? null : (
           <View
             style={{

--- a/frontend/app/src/components/Screen.js
+++ b/frontend/app/src/components/Screen.js
@@ -174,10 +174,10 @@ export default function Screen(props) {
 
   return (
     <View style={{ flex: 1, flexDirection: "row" }}>
-      <View style={{ flex: 5 }}>{renderVisualisation()}</View>
+      <View style={{ flex: 3 }}>{renderVisualisation()}</View>
       <Menu
         style={{
-          flex: 2,
+          width: 100,
           borderLeftWidth: 2,
           borderColor: theme.colors.border,
           padding: 10,

--- a/frontend/app/src/components/Screen.js
+++ b/frontend/app/src/components/Screen.js
@@ -108,6 +108,9 @@ export default function Screen(props) {
       if (!data.length) {
         throw "No data available for this time period";
       }
+      data.forEach((sample) => {
+        sample.timestamp = Date.parse(sample.timestamp);
+      }); // Store times as Unix timestamps
       setData(data);
       const allReadings = data.reduce(
         (acc, { timestamp, ...readings }) =>

--- a/frontend/app/src/components/Screen.js
+++ b/frontend/app/src/components/Screen.js
@@ -178,6 +178,7 @@ export default function Screen(props) {
           data={data}
           liveMode={liveMode}
           liveData={liveData}
+          screenState={screenState}
           chartOptions={chartOptions}
         />
       );

--- a/frontend/app/src/components/Screen.js
+++ b/frontend/app/src/components/Screen.js
@@ -1,5 +1,5 @@
 import React, { useState, useContext, useEffect } from "react";
-import { View } from "react-native";
+import { View, Alert } from "react-native";
 
 import Menu from "./Menu";
 import Model from "./Model";
@@ -105,6 +105,9 @@ export default function Screen(props) {
         startTime.toISOString(),
         endTime.toISOString()
       );
+      if (!data.length) {
+        throw "No data available for this time period";
+      }
       setData(data);
       const allReadings = data.reduce(
         (acc, { timestamp, ...readings }) =>
@@ -146,7 +149,7 @@ export default function Screen(props) {
         scale: modelOptions.colourMode ? modelColourScale[dataType] : dataRange,
       });
     } catch (error) {
-      console.error(error);
+      Alert.alert("Refresh error", error);
     }
     setIsLoading(false);
   }

--- a/frontend/app/src/models/BasementModel.js
+++ b/frontend/app/src/models/BasementModel.js
@@ -16,7 +16,7 @@ export default function BasementModel(props) {
   );
 
   useEffect(() => {
-    camera.zoom = props.zoom;
+    camera.zoom = props.zoom * 0.6;
     camera.updateProjectionMatrix();
   }, [props.zoom]);
 

--- a/frontend/app/src/models/StrongFloorModel.js
+++ b/frontend/app/src/models/StrongFloorModel.js
@@ -16,7 +16,7 @@ export default function StrongFloorModel(props) {
   ]);
 
   useEffect(() => {
-    camera.zoom = props.zoom;
+    camera.zoom = 2 * props.zoom;
     camera.updateProjectionMatrix();
   }, [props.zoom]);
 

--- a/frontend/app/src/utils/fetchData.js
+++ b/frontend/app/src/utils/fetchData.js
@@ -1,4 +1,5 @@
 import Papa from "papaparse";
+import { Alert } from "react-native";
 
 export default async function fetchData(
   sensorPackage,
@@ -7,22 +8,18 @@ export default async function fetchData(
   startTime,
   endTime
 ) {
-  try {
-    const response = await fetch(
-      `http://129.169.72.175/fbg/${sensorPackage}/${dataType}/?averaging-window=${averagingWindow}&start-time=${startTime}&end-time=${endTime}`,
-      {
-        method: "GET",
-        headers: { "media-type": "application/json" },
-      }
-    );
-    const data = await response.json();
-    data.forEach((sample) => {
-      sample.timestamp = Date.parse(sample.timestamp);
-    }); // Store times as Unix timestamps
-    return data;
-  } catch (error) {
-    console.error(error);
+  const response = await fetch(
+    `http://129.169.72.175/fbg/${sensorPackage}/${dataType}/?averaging-window=${averagingWindow}&start-time=${startTime}&end-time=${endTime}`,
+    {
+      method: "GET",
+      headers: { "media-type": "application/json" },
+    }
+  );
+  const data = await response.json();
+  if (response.status !== 200) {
+    throw data.detail;
   }
+  return data;
 }
 
 // Returns an array of dates between two dates

--- a/frontend/app/src/utils/fetchData.js
+++ b/frontend/app/src/utils/fetchData.js
@@ -51,7 +51,7 @@ export async function fetchTemperatureData(startTime, endTime) {
       temperatureData.push(
         ...parsedData.data.map((sample) => ({
           timestamp: date.setHours(...sample[0].split(":")),
-          temperature: sample[1],
+          temperature: parseFloat(sample[1]),
         }))
       );
     } catch (error) {

--- a/frontend/app/src/utils/index.js
+++ b/frontend/app/src/utils/index.js
@@ -7,3 +7,4 @@ export { default as theme } from "./theme";
 export { default as chartColours } from "./chartColours";
 export { default as modelColourScale } from "./modelColourScale";
 export { default as LiveStatusContext } from "./LiveStatusContext";
+export { default as labels } from "./labels";

--- a/frontend/app/src/utils/labels.js
+++ b/frontend/app/src/utils/labels.js
@@ -1,0 +1,23 @@
+const dataTypeLabels = [
+  { label: "Raw", value: "raw" },
+  { label: "Strain", value: "str" },
+  { label: "Temperature", value: "tmp" },
+];
+
+const averagingWindowLabels = [
+  { label: "---", value: "" },
+  { label: "Millisecond", value: "milliseconds" },
+  { label: "Second", value: "second" },
+  { label: "Minute", value: "minute" },
+  { label: "Hour", value: "hour" },
+  { label: "Day", value: "day" },
+  { label: "Week", value: "week" },
+  { label: "Month", value: "month" },
+];
+
+const labels = {
+  "Data Type": dataTypeLabels,
+  "Averaging Window": averagingWindowLabels,
+};
+
+export default labels;

--- a/frontend/app/src/utils/labels.js
+++ b/frontend/app/src/utils/labels.js
@@ -1,7 +1,7 @@
 const dataTypeLabels = [
-  { label: "Raw", value: "raw" },
-  { label: "Strain", value: "str" },
-  { label: "Temperature", value: "tmp" },
+  { label: "Raw", value: "raw", unit: "nm" },
+  { label: "Strain", value: "str", unit: "με" },
+  { label: "Temperature", value: "tmp", unit: "°C" },
 ];
 
 const averagingWindowLabels = [


### PR DESCRIPTION
- Made the menu and modal selectors scrollable lists with `ScrollView`.
- Store the state of the currently displayed data in `screenState` and show the current selection on the menu buttons. Note that the currently displayed selection does not necessarily match the menu state as the display only triggers upon clicking Refresh in historical mode.
- Added a help modal overlay triggered by clicking the question mark icon in the header bar. It introduces the app, highlights key functionality and explains the sensor naming conventions.
- Added a units label on the main Y axis of the chart e.g. με.
- Live indicator goes solid grey when the monitoring system is not live.
- Added reset buttons to both the model view and chart view which reset the view back to its initial state.
- Catch any API errors (e.g. start time is later than end time) and show an alert to inform the user.
- If returned data array is empty, do not refresh with new data and show alert to the user.
- Note that timestamps are sent to the API in GMT, but those received are in local time (e.g. dependent on summer time). This means the model and chart views will display BST times whilst the menu buttons will read GMT times. This is to avoid ambiguity in the selection of the start time and end time in the event that the time period crosses the BST line.